### PR TITLE
Farm visibility fix

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="69">
-    <version>1.0.0.0</version>
+    <version>1.0.0.1</version>
 	<author>Courseplay.devTeam, tn4799</author>
 	<title>
 		<en>Challenge Mode</en>
@@ -39,6 +39,10 @@ What is planed for the future:
 We suggest you for a 24/7 Server to use the Mod limited daily income, for more fairness.
 
 For more information, help, and report issues please visit <a href="https://github.com/Courseplay/ChallengeMode_FS22">github</a>.
+
+Changelog
+V1.0.0.1
+ - fixed farm visiblity bug
 ]]>
 </en>
 		<de><![CDATA[
@@ -72,6 +76,10 @@ Was ist für die Zukunft geplant:
 Wir empfehlen euch für einen 24/7 Server für mehr Fairness die Mod Tägliche Einkommensbegrenzung zu nutzen.
 
 Für mehr Informationen, Hilfe und Fehlermeldungen, schaut bitte auf <a href="https://github.com/Courseplay/ChallengeMode_FS22">Github</a> vorbei.
+
+Änderungsverlauf
+V1.0.0.1
+ - Fehler mit der Sichtbarkeit von Farmen behoben
 ]]></de>
     </description>
 
@@ -96,7 +104,7 @@ Für mehr Informationen, Hilfe und Fehlermeldungen, schaut bitte auf <a href="ht
 		<sourceFile filename="events/ChangeAdminPasswordEvent.lua"/>
 		<sourceFile filename="events/ChangeFarmVisibilityEvent.lua"/>
 		<sourceFile filename="events/ChangeGoalEvent.lua"/>
-		<sourceFile filename="events/AddPointsEvent.lua"/> 
+		<sourceFile filename="events/AddPointsEvent.lua"/>
 	</extraSourceFiles>
 
 	<l10n filenamePrefix="translations/translation" />

--- a/scripts/main.lua
+++ b/scripts/main.lua
@@ -21,10 +21,6 @@ function ChallengeMod.new(custom_mt)
 	self.visibleFarms = {}
 	self.isAdminModeActive = false
 
-	for i = 0, FarmManager.MAX_FARM_ID do
-		self.visibleFarms[i] = true
-	end
-
 	if ChallengeMod.isDevelopmentVersion then
 		addConsoleCommand('CmGenerateContracts', 'Generates new contracts', 'consoleGenerateFieldMission', g_missionManager)
 		CmUtil.debugActive = true
@@ -33,8 +29,13 @@ function ChallengeMod.new(custom_mt)
 	return self
 end
 
+function ChallengeMod:newFarmCreated(farmId)
+	self.visibleFarms[farmId] = true
+end
+
 function ChallengeMod:changeFarmVisibility(farmId, visible, noEvent)
 	if self.visibleFarms[farmId] ~= nil then
+		CmUtil.debug("Change visibility of farm %s", farmId)
 		if visible == nil then
 			self.visibleFarms[farmId] = not self.visibleFarms[farmId]
 		else
@@ -175,7 +176,7 @@ function ChallengeMod:saveToXMLFile(filename)
 		local i = 0
 		for farmId, visible in pairs(self.visibleFarms) do
 			xmlFile:setValue(string.format("%s.Farms.Farm(%d)#id", self.baseXmlKey, i), farmId)
-			xmlFile:setValue(string.format("%s.Farms.Farm(%d)#visible", self.baseXmlKey, i), visible or true)
+			xmlFile:setValue(string.format("%s.Farms.Farm(%d)#visible", self.baseXmlKey, i), visible)
 			i = i + 1
 		end
 		g_ruleManager:saveToXMLFile(xmlFile, self.baseXmlKey)

--- a/scripts/main.lua
+++ b/scripts/main.lua
@@ -20,6 +20,7 @@ function ChallengeMod.new(custom_mt)
 	self.isServer = g_server
 	self.visibleFarms = {}
 	self.isAdminModeActive = false
+	g_messageCenter:subscribe(MessageType.FARM_CREATED, self.newFarmCreated, self)
 
 	if ChallengeMod.isDevelopmentVersion then
 		addConsoleCommand('CmGenerateContracts', 'Generates new contracts', 'consoleGenerateFieldMission', g_missionManager)


### PR DESCRIPTION
When loading in a game after restart the farms that previously were hidden are visible. 
This behaviour happended because on the save of the visibility it was always true because of the intended nil-check.
Also removed saving visibility for all farmIds, even if not all are created. 
Instead now set it if a farm is created.