### PR TITLE
Limit Challenge duration

### DIFF
--- a/events/ChallengeOverEvent.lua
+++ b/events/ChallengeOverEvent.lua
@@ -1,0 +1,45 @@
+ChallengeOverEvent = {}
+
+ChallengeOverEvent_mt = Class(ChallengeOverEvent, Event)
+
+InitEventClass(ChallengeOverEvent, "ChallengeOverEvent")
+
+function ChallengeOverEvent.emptyNew()
+    return Event.new(ChallengeOverEvent_mt)
+end
+
+function ChallengeOverEvent.new(finalPoints, farmId)
+    local self = ChallengeOverEvent.emptyNew()
+
+    self.finalPoints = finalPoints
+    self.farmId = farmId
+
+    return self
+end
+
+function ChallengeOverEvent:writeStream(streamId, connection)
+    streamWriteInt32(streamId, self.finalPoints)
+    streamWriteInt8(streamId, self.farmId)
+end
+
+function ChallengeOverEvent:readStream(streamId, connection)
+    self.finalPoints = streamReadInt32(streamId)
+    self.farmId = streamReadInt8(streamId)
+
+    self:run(connection)
+end
+
+function ChallengeOverEvent:run(connection)
+    if not connection:getIsServer() then
+        g_server:broadcastEvent(ChallengeOverEvent.new(self.finalPoints, self.farmId), nil, connection)
+    end
+    g_challengeMod:setFinalPointsForFarm(self.finalPoints, self.farmId, true)
+end
+
+function ChallengeOverEvent.sendEvent(...)
+    if g_server ~= nil then
+        g_server:broadcastEvent(ChallengeOverEvent.new(...))
+    else
+        g_client:getServerConnection():sendEvent(ChallengeOverEvent.new(...))
+    end
+end

--- a/events/ChangeDurationEvent.lua
+++ b/events/ChangeDurationEvent.lua
@@ -2,6 +2,8 @@ ChangeDurationEvent = {}
 
 ChangeDurationEvent_mt = Class(ChangeDurationEvent, Event)
 
+InitEventClass(ChangeDurationEvent, "ChangeDurationEvent")
+
 function ChangeDurationEvent.emptyNew()
     return Event.new(ChangeDurationEvent_mt)
 end

--- a/events/ChangeDurationEvent.lua
+++ b/events/ChangeDurationEvent.lua
@@ -1,0 +1,41 @@
+ChangeDurationEvent = {}
+
+ChangeDurationEvent_mt = Class(ChangeDurationEvent, Event)
+
+function ChangeDurationEvent.emptyNew()
+    return Event.new(ChangeDurationEvent_mt)
+end
+
+function ChangeDurationEvent.new(duration)
+    local self = ChangeDurationEvent.emptyNew()
+
+    self.duration = duration
+
+    return self
+end
+
+function ChangeDurationEvent:writeStream(streamId, connection)
+    streamWriteInt32(streamId, self.duration)
+end
+
+function ChangeDurationEvent:readStream(streamId, connection)
+    self.duration = streamReadInt32(streamId)
+
+    self:run(connection)
+end
+
+function ChangeDurationEvent:run(connection)
+    if not connection:getIsServer() then
+        g_server:broadcastEvent(ChangeDurationEvent.new(self.duration), nil, connection)
+    end
+
+    g_challengeMod:setDuration(self.duration, true)
+end
+
+function ChangeDurationEvent.sendEvent(...)
+    if g_server ~= nil then
+        g_server:broadcastEvent(ChangeDurationEvent.new(...))
+    else
+        g_client:getServerConnection():sendEvent(ChangeDurationEvent.new(...))
+    end
+end

--- a/gui/ScoreBoardFrame.lua
+++ b/gui/ScoreBoardFrame.lua
@@ -97,6 +97,9 @@ function ScoreBoardFrame:onGuiSetupFinished()
 	self.leftList:setDataSource(self)
 	self.rightList:setDataSource(self)
 	self.changelogList:setDataSource(self)
+	if not g_challengeMod:isTimeTracked() then
+		self.headerDuration:setVisible(false)
+	end
 
 	-- Save the current selected list to decide which buttons will be shown and which not
 	local orig = self.leftList.onFocusEnter

--- a/gui/ScoreBoardFrame.lua
+++ b/gui/ScoreBoardFrame.lua
@@ -37,6 +37,7 @@ ScoreBoardFrame = {
 
 ScoreBoardFrame.translations = {
 	goal = function(goal) return string.format(g_i18n:getText("CM_rightList_leftTitle"), goal) end,
+	headerDuration = function (timePassed, duration) return string.format(g_i18n:getText("CM_title_duration"), timePassed, duration) end,
 
 	ruleTitle = g_i18n:getText("CM_leftList_ruleTitle"),
 	adminPointsTitle = g_i18n:getText("CM_leftList_adminPointsTitle"),
@@ -100,6 +101,11 @@ function ScoreBoardFrame:onGuiSetupFinished()
 	if not g_challengeMod:isTimeTracked() then
 		self.headerDuration:setVisible(false)
 	end
+
+	self.goal.overlay.alpha = 0
+	self.goal.textDisabledColor = self.goal.textColor
+	self.headerDuration.overlay.apha = 0
+	self.headerDuration.textDisabledColor = self.headerDuration.textColor
 
 	-- Save the current selected list to decide which buttons will be shown and which not
 	local orig = self.leftList.onFocusEnter
@@ -289,6 +295,7 @@ function ScoreBoardFrame:updateTitles()
 	local sx, ix = self.leftList:getSelectedPath()
 	local titles = self.managers[sx]():getTitles()
 	self.goal:setText(self.translations.goal(self.victoryPointManager:getGoal()))
+	self.headerDuration:setText(self.translations.headerDuration(g_challengeMod:getTimePassed(), g_challengeMod:getDuration()))
 	self.rightList_middleTitle:setText(titles[2])
 	self.rightList_rightTitle:setText(titles[3])
 end
@@ -303,9 +310,8 @@ function ScoreBoardFrame:updateMenuButtons()
 	self:setMenuButtonInfoDirty()
 
 	self.goal:setDisabled(not g_challengeMod.isAdminModeActive, false)
-
-	self.goal.overlay.alpha = 0
-	self.goal.textDisabledColor = self.goal.textColor
+	self.headerDuration:setDisabled(not g_challengeMod.isAdminModeActive, false)
+	self.headerDuration:setVisible(not g_challengeMod.isAdminModeActive or g_challengeMod:isTimeTracked())
 end
 
 function ScoreBoardFrame:getNumberOfSections(list)

--- a/gui/ScoreBoardFrame.lua
+++ b/gui/ScoreBoardFrame.lua
@@ -1,6 +1,7 @@
 ScoreBoardFrame = {
 	CONTROLS = {
 		HEADER = "header",
+		HEADER_DURATION = "headerDuration",
 		MAIN_BOC = "mainBox",
 		LEFT_COLUMN = "leftColumn",
 		RIGHT_COLUMN = "rightColumn",

--- a/gui/ScoreBoardFrame.xml
+++ b/gui/ScoreBoardFrame.xml
@@ -7,7 +7,7 @@
                 <GuiElement type="text" profile="Header" id="header" text="$l10n_CM_title"/>
             </GuiElement>
             <GuiElement type="empty" profile="RightHeaderBox">
-                <GuiElement type="text" profile="RightHeader" id="headerDuration" text="$l10n_CM_title_duration"/>
+                <GuiElement type="button" profile="RightHeader" id="headerDuration" onClick="onClickSetDuration"/>
             </GuiElement>
         </GuiElement>
 

--- a/gui/ScoreBoardFrame.xml
+++ b/gui/ScoreBoardFrame.xml
@@ -3,7 +3,12 @@
     <GuiElement type="empty" profile="uiInGameMenuFrame">
         <GuiElement type="empty" profile="ingameMenuFrameHeaderPanel">
             <GuiElement type="bitmap" profile="ingameMenuPriceHeaderIcon" />
-            <GuiElement type="text" profile="ingameMenuFrameHeaderText" id="header" text="$l10n_CM_title"/>
+            <GuiElement type="empty" profile="LeftHeaderBox">
+                <GuiElement type="text" profile="Header" id="header" text="$l10n_CM_title"/>
+            </GuiElement>
+            <GuiElement type="empty" profile="RightHeaderBox">
+                <GuiElement type="text" profile="RightHeader" id="headerDuration" text="$l10n_CM_title_duration"/>
+            </GuiElement>
         </GuiElement>
 
         <GuiElement type="empty" profile="ingameMenuSettingsBox" id="mainBox">
@@ -32,7 +37,7 @@
 
             <GuiElement type="empty" profile="ingameMenuPriceRightColumn" id="rightColumn">
                 <GuiElement type="boxLayout" profile="ingameCalendarHeaderBox" id="tableHeaderBox" size="680px 104px">
-                    <GuiElement type="button" profile="ingameMenuPriceHeader" size="330px 104px"  id="goal" text="" onClick="onClickSetGoal"/> 
+                    <GuiElement type="button" profile="ingameMenuPriceHeader" size="330px 104px"  id="goal" text="" onClick="onClickSetGoal"/>
                     <GuiElement type="text" profile="ingameMenuPriceHeader" size="180px 104px"  text="" id="rightList_middleTitle" />
                     <GuiElement type="text" profile="ingameMenuPriceHeader" size="160px 104px"  text="" id="rightList_rightTitle" textOffset="0 0" />
                 </GuiElement>
@@ -56,7 +61,7 @@
 
             <GuiElement type="empty" profile="ingameMenuPriceRightColumn" id="changelogColumn" visible="false">
                 <GuiElement type="boxLayout" profile="ingameCalendarHeaderBox" id="changelogColumnHeaderBox" size="680px 104px">
-                    <GuiElement type="text" profile="ingameMenuPriceHeader" size="190px 104px" text="$l10n_CM_changelogList_leftTitle" id="changelogList_leftTitle" /> 
+                    <GuiElement type="text" profile="ingameMenuPriceHeader" size="190px 104px" text="$l10n_CM_changelogList_leftTitle" id="changelogList_leftTitle" />
                     <GuiElement type="text" profile="ingameMenuPriceHeader" size="330px 104px" text="$l10n_CM_changelogList_middleTitle" id="changelogList_middleTitle" />
                     <GuiElement type="text" profile="ingameMenuPriceHeader" size="160px 104px" text="$l10n_CM_changelogList_rightTitle" id="changelogList_rightTitle" textOffset="0 0" />
                 </GuiElement>

--- a/gui/guiProfiles.xml
+++ b/gui/guiProfiles.xml
@@ -177,7 +177,7 @@
 		<Value name="autoValidateLayout" value="true"/>
 		<Value name="flowDirection" value="horizontal"/>
     </Profile>
-	
+
 	<Profile name="lpsHeader" extends="textDefault" with="anchorMiddleLeft">
         <Value name="textSize" value="24px" />
         <Value name="textBold" value="true" />
@@ -243,7 +243,7 @@
     </Profile>
 
 	<Profile name="CmDialogTextInput" extends="dialogTextInput" with="anchorMiddleCenter">
-		<Value name="textSize" value="18px"/> 
+		<Value name="textSize" value="18px"/>
         <Value name="maxCharacters" value="300"/>
     </Profile>
     <Profile name="CmDialogPointsTextInput" extends="CmDialogTextInput" with="anchorMiddleCenter">
@@ -254,7 +254,7 @@
     </Profile>
 
     <Profile name="CmChangelogUserNameText" extends="textDefault" with="anchorMiddleLeft">
-        <Value name="size" value="190px 50px"/> 
+        <Value name="size" value="190px 50px"/>
         <Value name="textVerticalAlignment" value="middle" />
         <Value name="textAutoWidth" value="true" />
         <Value name="position" value="45px 0" />
@@ -272,6 +272,20 @@
         <Value name="textVerticalAlignment" value="middle" />
         <Value name="format" value="currency" />
         <Value name="position" value="520px 0" />
+    </Profile>
+
+    <Profile name="LeftHeaderBox" extends="emptyPanel" with="anchorTopLeft">
+        <Value name="size" value="600px 64px"/>
+    </Profile>
+
+    <Profile name="RightHeaderBox" extends="LeftHeaderBox" with="anchorTopRight"/>
+
+    <Profile name="Header" extends="ingameMenuFrameHeaderText" with="anchorMiddleLeft">
+        <Value name="size" value="550px 64px"/>
+    </Profile>
+
+    <Profile name="RightHeader" extends="Header" with="anchorMiddleRight">
+        <Value name="textAlignment" value="right"/>
     </Profile>
 
 </GUIProfiles>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
-<modDesc descVersion="71">
+<modDesc descVersion="72">
     <version>1.1.0.0</version>
 	<author>Courseplay.devTeam, tn4799</author>
 	<title>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -110,6 +110,7 @@ V1.1.0.0
 		<sourceFile filename="events/ChangeAdminPasswordEvent.lua"/>
 		<sourceFile filename="events/ChangeFarmVisibilityEvent.lua"/>
 		<sourceFile filename="events/ChangeGoalEvent.lua"/>
+		<sourceFile filename="events/ChangeDurationEvent.lua"/>
 		<sourceFile filename="events/AddPointsEvent.lua"/>
 	</extraSourceFiles>
 

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -111,6 +111,7 @@ V1.1.0.0
 		<sourceFile filename="events/ChangeFarmVisibilityEvent.lua"/>
 		<sourceFile filename="events/ChangeGoalEvent.lua"/>
 		<sourceFile filename="events/ChangeDurationEvent.lua"/>
+		<sourceFile filename="events/ChallengeOverEvent.lua"/>
 		<sourceFile filename="events/AddPointsEvent.lua"/>
 	</extraSourceFiles>
 

--- a/scripts/VictoryPointManager.lua
+++ b/scripts/VictoryPointManager.lua
@@ -246,6 +246,10 @@ end
 function VictoryPointManager:calculatePoints(farmId)
 	self.pointList[farmId] = self:getNewPointList(farmId)
 	self.totalPoints[farmId] = self.pointList[farmId]:count() + self:sumAdditionalPoints(farmId)
+
+	if g_challengeMod:isDurationOver() then
+		self.totalPoints = g_challengeMod:getFinalPointList()
+	end
 end
 
 function VictoryPointManager:sumAdditionalPoints(farmId)

--- a/scripts/VictoryPointManager.lua
+++ b/scripts/VictoryPointManager.lua
@@ -247,8 +247,8 @@ function VictoryPointManager:calculatePoints(farmId)
 	self.pointList[farmId] = self:getNewPointList(farmId)
 	self.totalPoints[farmId] = self.pointList[farmId]:count() + self:sumAdditionalPoints(farmId)
 
-	if g_challengeMod:isDurationOver() then
-		self.totalPoints = g_challengeMod:getFinalPointList()
+	if g_challengeMod:isDurationOver() and g_challengeMod:areFinalPointsSetForFarm(farmId) then
+		self.totalPoints[farmId] = g_challengeMod:getFinalPointListForFarm(farmId)
 	end
 end
 

--- a/scripts/main.lua
+++ b/scripts/main.lua
@@ -186,7 +186,7 @@ function ChallengeMod:registerXmlSchema()
 	self.xmlSchema:register(XMLValueType.BOOL, self.baseXmlKey .. "#trackDuration", "Specifies if the duration is tracked or not", false)
 	self.xmlSchema:register(XMLValueType.INT, self.baseXmlKey .. ".Farms.Farm(?)#id", "Farm id")
 	self.xmlSchema:register(XMLValueType.BOOL, self.baseXmlKey .. ".Farms.Farm(?)#visible", "Farm visible", true)
-	self.xmlSchema:register(XMLValueType.BOOL, self.baseXmlKey .. ".Farms.Farm(?)#finalPoints", "Final points of farm when challenge is over.")
+	self.xmlSchema:register(XMLValueType.INT, self.baseXmlKey .. ".Farms.Farm(?)#finalPoints", "Final points of farm when challenge is over.")
 	local key = self.baseXmlKey .. ".TimeLimit"
 	self.xmlSchema:register(XMLValueType.INT, key .. ".Duration", "How long the Challenge will go at most.")
 	self.xmlSchema:register(XMLValueType.INT, key .. ".TimePassed", "The current Month of the Challenge.", 1)

--- a/scripts/main.lua
+++ b/scripts/main.lua
@@ -73,6 +73,10 @@ function ChallengeMod:getDefaultAdminPassword()
 	return self.defaultAdminPassword
 end
 
+function ChallengeMod:isTimeTracked()
+	return self.trackDuration
+end
+
 function ChallengeMod:getDuration()
 	return self.duration
 end

--- a/scripts/main.lua
+++ b/scripts/main.lua
@@ -22,9 +22,10 @@ function ChallengeMod.new(custom_mt)
 	self.finalPoints = {}
 	self.isAdminModeActive = false
 	self.trackDuration = false
-	g_messageCenter:subscribe(MessageType.FARM_CREATED, self.newFarmCreated, self)
 	self.timePassed = 1
 	self.duration = 0
+
+	g_messageCenter:subscribe(MessageType.FARM_CREATED, self.newFarmCreated, self)
 
 	if ChallengeMod.isDevelopmentVersion then
 		addConsoleCommand('CmGenerateContracts', 'Generates new contracts', 'consoleGenerateFieldMission', g_missionManager)
@@ -223,7 +224,7 @@ function ChallengeMod:saveToXMLFile(filename)
 		for farmId, visible in pairs(self.visibleFarms) do
 			local key = string.format("%s.Farms.Farm(%d)", self.baseXmlKey, i)
 			xmlFile:setValue(key .. "#id", farmId)
-			xmlFile:setValue(key .. "#visible", visible or true)
+			xmlFile:setValue(key .. "#visible", visible)
 
 			if self:isDurationOver() and visible then
 				xmlFile:setValue(key .. "#finalPoints", self.finalPoints[farmId])

--- a/scripts/main.lua
+++ b/scripts/main.lua
@@ -84,6 +84,15 @@ function ChallengeMod:setDuration(duration, noEvent)
 	end
 end
 
+function ChallengeMod:setFinalPointsForFarm(finalPoints, farmId, noEventSend)
+	CmUtil.debug("set final points of farmId %s to %s", farmId, finalPoints)
+	self.finalPoints[farmId] = finalPoints
+
+	if noEventSend == nil or not noEventSend then
+		ChallengeOverEvent.sendEvent(finalPoints, farmId)
+	end
+end
+
 function ChallengeMod:getAdminPassword()
 	return self.adminPassword
 end
@@ -110,6 +119,14 @@ end
 
 function ChallengeMod:getFinalPointList()
 	return self.finalPoints
+end
+
+function ChallengeMod:getFinalPointListForFarm(farmId)
+	return self.finalPoints[farmId]
+end
+
+function ChallengeMod:areFinalPointsSetForFarm(farmId)
+	return self.finalPoints[farmId] ~= nil
 end
 
 function ChallengeMod:loadMap()
@@ -400,7 +417,7 @@ function ChallengeMod:onPeriodChanged()
 			for _, farm in pairs(g_farmManager:getFarms()) do
 				local farmId = farm.farmId
 				g_victoryPointManager:calculatePoints(farmId)
-				self.finalPoints[farmId] = g_victoryPointManager:getTotalPoints(farmId)
+				self:setFinalPointsForFarm(g_victoryPointManager:getTotalPoints(farmId), farmId)
 			end
 		end
 	end

--- a/scripts/main.lua
+++ b/scripts/main.lua
@@ -97,7 +97,7 @@ function ChallengeMod:isTimeTracked()
 end
 
 function ChallengeMod:isDurationOver()
-	return self.timePassed > self.duration
+	return self.trackDuration and self.timePassed > self.duration
 end
 
 function ChallengeMod:getDuration()

--- a/scripts/main.lua
+++ b/scripts/main.lua
@@ -242,6 +242,7 @@ function ChallengeMod:loadFromXMLFile(filename)
 
 		if not xmlFile:hasProperty(self.baseXmlKey .. "#trackDuration") then
 			self:setDuration(0)
+			self.trackDuration = false
 		else
 			self.trackDuration = xmlFile:getValue(self.baseXmlKey .. "#trackDuration")
 		end

--- a/scripts/main.lua
+++ b/scripts/main.lua
@@ -65,7 +65,7 @@ function ChallengeMod:changeAdminPassword(newPassword, noEvent)
 	end
 end
 
-function ChallengeMod:setDuration(duration)
+function ChallengeMod:setDuration(duration, noEvent)
 	self.duration = duration
 
 	if duration == 0 then
@@ -74,6 +74,10 @@ function ChallengeMod:setDuration(duration)
 	else
 		self.trackDuration = true
 		g_messageCenter:subscribe(MessageType.PERIOD_CHANGED, self.onPeriodChanged, self)
+	end
+
+	if noEvent == nil or not noEvent then
+		ChangeDurationEvent.sendEvent(duration)
 	end
 end
 
@@ -308,6 +312,7 @@ function ChallengeMod:writeStream(streamId, connection)
 	end
 	streamWriteInt8(streamId, -1)
 
+	--TODO: implement sync of duration linked stuff
 	g_ruleManager:writeStream(streamId, connection)
 	g_victoryPointManager:writeStream(streamId, connection)
 end
@@ -327,6 +332,7 @@ function ChallengeMod:readStream(streamId, connection)
 		end
 		self.visibleFarms[id] = streamReadBool(streamId)
 	end
+	--TODO: implement sync of duration linked stuff
 	g_ruleManager:readStream(streamId, connection)
 	g_victoryPointManager:readStream(streamId, connection)
 end

--- a/scripts/main.lua
+++ b/scripts/main.lua
@@ -388,6 +388,7 @@ end
 ItemSystem.save = Utils.prependedFunction(ItemSystem.save, ChallengeMod.saveToSaveGame)
 
 function ChallengeMod:onPeriodChanged()
+	CmUtil.debug("month changed. Increase Time passed by 1")
 	self.timePassed = self.timePassed + 1
 
 	if self:isDurationOver() then

--- a/scripts/main.lua
+++ b/scripts/main.lua
@@ -186,6 +186,7 @@ function ChallengeMod:registerXmlSchema()
 	self.xmlSchema:register(XMLValueType.BOOL, self.baseXmlKey .. "#trackDuration", "Specifies if the duration is tracked or not", false)
 	self.xmlSchema:register(XMLValueType.INT, self.baseXmlKey .. ".Farms.Farm(?)#id", "Farm id")
 	self.xmlSchema:register(XMLValueType.BOOL, self.baseXmlKey .. ".Farms.Farm(?)#visible", "Farm visible", true)
+	self.xmlSchema:register(XMLValueType.BOOL, self.baseXmlKey .. ".Farms.Farm(?)#finalPoints", "Final points of farm when challenge is over.")
 	local key = self.baseXmlKey .. ".TimeLimit"
 	self.xmlSchema:register(XMLValueType.INT, key .. ".Duration", "How long the Challenge will go at most.")
 	self.xmlSchema:register(XMLValueType.INT, key .. ".TimePassed", "The current Month of the Challenge.", 1)

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -2,6 +2,7 @@
 <l10n>
 	<texts>
 		<text name="CM_title" 													text="Wettkampfmodus" />
+		<text name="CM_title_duration"											text="Monat %s von %s"/>
 		<text name="CM_leftList_leftTitle" 										text="Farm" />
 		<text name="CM_leftList_rightTitle" 									text="Gesamtpunkte" />
 		<text name="CM_leftList_section_two" 									text="Einstellungen" />
@@ -41,7 +42,7 @@
 		<text name="CM_dialog_addPoints_error_zeroPoints" 						text="Die Punkte dürfen nicht 0 sein!"/>
 		<text name="CM_dialog_addPoints_error_notANumber" 						text="Punkte müssen eine Zahl sein!"/>
 		<text name="CM_dialog_setGoal_error_invalidGoal" 						text="Ziel muss eine Zahl sein!"/>
-		
+
 
 		<text name="CM_VictoryPoints_leftTitle" 								text=""/>
 		<text name="CM_VictoryPoints_middleTitle" 								text="Faktor"/>
@@ -60,7 +61,7 @@
 		<text name="CM_VictoryPoints_general_ownedBuildingValue_input_text" 	text="Gib ein wie viel Gebäudeverkaufswert einem Punkt entspricht."/>
 		<text name="CM_VictoryPoints_general_ownedVehicleValue_input_text" 		text="Gib ein wie viel Fahrzeugverkaufswert einem Punkt entspricht."/>
 		<text name="CM_VictoryPoints_general_productionValue_input_text" 		text="Gib ein wie viel Produktionswert einem Punkt entspricht."/>
-		
+
 		<text name="CM_VictoryPoints_general_input_text_format"					text="Gib ein wie viel %s einem Punkt entspricht."/>
 		<text name="CM_VictoryPoints_storage_input_text_format"					text="Gib ein wie viel %s einem Punkt entspricht."/>
 		<text name="CM_VictoryPoints_bales_input_text_format"					text="Gib ein wie viel %s einem Punkt entspricht."/>

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -33,7 +33,9 @@
 		<text name="CM_dialog_adminChangePasswordTitle" 						text="Aktuelles Passwort: %s" />
 		<text name="CM_dialog_adminWrongPassword" 								text="Falsches Passwort! (%s)"/>
 		<text name="CM_dialog_newGoal" 											text="Gib das neue Ziel ein."/>
-		<text name="CM_dialog_newDuration"										text="Gib die Dauer in Monaten ein. \n Eine Dauer von 0 Monaten deaktiviert das Zeitlimit."/>
+		<text name="CM_dialog_newDuration"text="Gib die Dauer in Monaten ein.
+Eine Dauer von 0 Monaten deaktiviert das Zeitlimit."
+		/>
 		<text name="CM_dialog_challengeOver"									text="Der Wettkampf ist vorbei."/>
 
 		<text name="CM_dialog_addPoints_title"									text="Punkte hinzufügen"/>

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -34,6 +34,7 @@
 		<text name="CM_dialog_adminWrongPassword" 								text="Falsches Passwort! (%s)"/>
 		<text name="CM_dialog_newGoal" 											text="Gib das neue Ziel ein."/>
 		<text name="CM_dialog_newDuration"										text="Gib die Dauer in Monaten ein. \n Eine Dauer von 0 Monaten deaktiviert das Zeitlimit."/>
+		<text name="CM_dialog_challengeOver"									text="Der Wettkampf ist vorbei."/>
 
 		<text name="CM_dialog_addPoints_title"									text="Punkte hinzufügen"/>
 		<text name="CM_dialog_addPoints_pointsText"								text="Punkte"/>

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -33,6 +33,7 @@
 		<text name="CM_dialog_adminChangePasswordTitle" 						text="Aktuelles Passwort: %s" />
 		<text name="CM_dialog_adminWrongPassword" 								text="Falsches Passwort! (%s)"/>
 		<text name="CM_dialog_newGoal" 											text="Gib das neue Ziel ein."/>
+		<text name="CM_dialog_newDuration"										text="Gib die Dauer in Monaten ein. \n Eine Dauer von 0 Monaten deaktiviert das Zeitlimit."/>
 
 		<text name="CM_dialog_addPoints_title"									text="Punkte hinzufügen"/>
 		<text name="CM_dialog_addPoints_pointsText"								text="Punkte"/>
@@ -42,6 +43,7 @@
 		<text name="CM_dialog_addPoints_error_zeroPoints" 						text="Die Punkte dürfen nicht 0 sein!"/>
 		<text name="CM_dialog_addPoints_error_notANumber" 						text="Punkte müssen eine Zahl sein!"/>
 		<text name="CM_dialog_setGoal_error_invalidGoal" 						text="Ziel muss eine Zahl sein!"/>
+		<text name="CM_dialog_setDuration_error_invalidDuration" 				text="Dauer muss eine positive Zahl sein!"/>
 
 
 		<text name="CM_VictoryPoints_leftTitle" 								text=""/>

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -2,6 +2,7 @@
 <l10n>
 	<texts>
 		<text name="CM_title" 													text="Challenge mode" />
+		<text name="CM_title_duration"											text="Month %s of %s"/>
 		<text name="CM_leftList_leftTitle" 										text="Farm" />
 		<text name="CM_leftList_rightTitle" 									text="Total points" />
 		<text name="CM_leftList_section_two" 									text="Settings" />
@@ -90,7 +91,7 @@
 		<text name="CM_Rules_general_leaseVehicle_shopOnly"						text="Shop only"/>
 		<text name="CM_Rules_general_leaseVehicle_allowed"						text="Allowed"/>
 		<text name="CM_Rules_general_maxFillLevel_title"						text="Fill level cap: "/>
-		<text name="CM_Rules_general_maxFillLevel_deactivated"					text="Deactivated"/>			
+		<text name="CM_Rules_general_maxFillLevel_deactivated"					text="Deactivated"/>
 		<text name="CM_Rules_general_creditLimit_title"							text="Credit limit:"/>
 		<text name="CM_Rules_general_creditLimit_deactivated"					text="Deactivated"/>
 		<text name="CM_Rules_general_maxNumberOfAnimals_title" 					text="Max amount of counting Animals:"/>

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -34,6 +34,7 @@
 		<text name="CM_dialog_adminWrongPassword"								text="Wrong password (%s)"/>
 		<text name="CM_dialog_newGoal" 											text="Enter the new goal."/>
 		<text name="CM_dialog_newDuration"										text="Enter the duration in months. \n A duration of 0 months will deactivate the time limit."/>
+		<text name="CM_dialog_challengeOver"									text="The challenge is over."/>
 
 		<text name="CM_dialog_addPoints_title"									text="Add Points"/>
 		<text name="CM_dialog_addPoints_pointsText"								text="Points"/>

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -33,7 +33,9 @@
 		<text name="CM_dialog_adminChangePasswordTitle"							text="Current password: %s" />
 		<text name="CM_dialog_adminWrongPassword"								text="Wrong password (%s)"/>
 		<text name="CM_dialog_newGoal" 											text="Enter the new goal."/>
-		<text name="CM_dialog_newDuration"										text="Enter the duration in months. \n A duration of 0 months will deactivate the time limit."/>
+		<text name="CM_dialog_newDuration"										text="Enter the duration in months.
+A duration of 0 months will deactivate the time limit."
+		/>
 		<text name="CM_dialog_challengeOver"									text="The challenge is over."/>
 
 		<text name="CM_dialog_addPoints_title"									text="Add Points"/>

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -118,5 +118,4 @@
 		<text name="animalName_plural_chicken"									text="Chickens"/>
 		<text name="animalName_plural_sheep"									text="Sheeps"/>
 	</texts>
-	</texts>
 </l10n>

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -33,6 +33,7 @@
 		<text name="CM_dialog_adminChangePasswordTitle"							text="Current password: %s" />
 		<text name="CM_dialog_adminWrongPassword"								text="Wrong password (%s)"/>
 		<text name="CM_dialog_newGoal" 											text="Enter the new goal."/>
+		<text name="CM_dialog_newDuration"										text="Enter the duration in months. \n A duration of 0 months will deactivate the time limit."/>
 
 		<text name="CM_dialog_addPoints_title"									text="Add Points"/>
 		<text name="CM_dialog_addPoints_pointsText"								text="Points"/>
@@ -42,6 +43,7 @@
 		<text name="CM_dialog_addPoints_error_zeroPoints" 						text="Points cannot be 0!"/>
 		<text name="CM_dialog_addPoints_error_notANumber" 						text="Points have to be a number!"/>
 		<text name="CM_dialog_setGoal_error_invalidGoal" 						text="Goal have to be a number!"/>
+		<text name="CM_dialog_setDuration_error_invalidDuration" 				text="Duration has to be a positive number!"/>
 
 		<text name="CM_VictoryPoints_leftTitle"									text=""/>
 		<text name="CM_VictoryPoints_middleTitle"								text="Factor"/>

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -24,8 +24,8 @@
 		<text name="CM_menuBtn_hideChangelog" 									text="Hide Changelog" />
 		<text name="CM_menuBtn_addPoints" 										text="Add Points" />
 
-		<text name="CM_buttonText_markStartVehicle" 							text="starting vehicle" />
-		<text name="CM_buttonText_unmarkStartVehicle" 							text="no starting vehicle" />
+		<text name="CM_buttonText_markStartVehicle" 							text="Starting vehicle" />
+		<text name="CM_buttonText_unmarkStartVehicle" 							text="No starting vehicle" />
 
 		<text name="CM_dialog_changeTitle" 										text="Change value" />
 		<text name="CM_dialog_adminTitle" 										text="Login" />
@@ -33,7 +33,7 @@
 		<text name="CM_dialog_adminWrongPassword"								text="Wrong password (%s)"/>
 		<text name="CM_dialog_newGoal" 											text="Enter the new goal."/>
 
-		<text name="CM_dialog_addPoints_title"									text="add Points"/>
+		<text name="CM_dialog_addPoints_title"									text="Add Points"/>
 		<text name="CM_dialog_addPoints_pointsText"								text="Points"/>
 		<text name="CM_dialog_addPoints_reasonText"								text="Reason"/>
 


### PR DESCRIPTION
Adds the option to limit the duration of the challenge in ingame months.
If the duration is over (the duration is surpassed) the point list at that time will be saved and no more points can be earned.
In the top Right the duration is shown in the format Month _currentMonth_ of _duration_. Current month specifies the month that is active.

Closes #14 