### PR TITLE
fix size behavior calculation for syncing additonal points

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="77">
-    <version>1.2.0.0</version>
+    <version>1.2.0.1</version>
 	<author>Courseplay.devTeam, tn4799</author>
 	<title>
 		<en>Challenge Mode</en>
@@ -54,6 +54,9 @@ V1.1.0.1
 V1.2.0.0
  - Added an option for decreasing points if farm has a loan
  - Added an option to hide the other farms points, or pay to spy on the points as long as you are inside the menu
+
+V1.2.0.1
+ - Fixed a bug with the synchronization of additional points
 ]]>
 </en>
 		<de><![CDATA[
@@ -101,6 +104,9 @@ V1.1.0.1
 V1.2.0.0
  - Option hinzugefügt, dass ein Hof Punkte verliert, sollte der Hof einen Kredit haben
  - Option hinzugefügt um die Punktezusammensetzung der anderen Farmen zu verstecken, oder bazahle um die Punkte zu sehen solange du im Menü bist
+
+V1.2.0.1
+ - Fehler bei der Synchronisation der zusätzlichen Punkte behoben
 ]]></de>
        <fr><![CDATA[
 Voici le Farming compétitif !

--- a/scripts/VictoryPointManager.lua
+++ b/scripts/VictoryPointManager.lua
@@ -108,9 +108,9 @@ function VictoryPointManager:writeStream(streamId, connection)
 	streamWriteInt32(streamId, self.victoryGoal)
 
 	--tell client number of elements
-	streamWriteInt32(streamId, #self.additionalPoints)
+	streamWriteInt32(streamId, table.size(self.additionalPoints))
 	for farmId, points in pairs(self.additionalPoints) do
-		streamWriteInt32(streamId, #points)
+		streamWriteInt32(streamId, table.size(points))
 		for _, point in pairs(points) do
 			streamWriteInt8(streamId, farmId)
 			streamWriteInt32(streamId, point.points)


### PR DESCRIPTION
When a farm, that is not farm 1 has additional points, those where not synced correctly. this now should be fixed