### PR TITLE
Giants object storage support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Giants Studio project files
+*.gsp
+*.gspu
+
 # Compiled Lua sources
 luac.out
 

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="77">
-    <version>1.2.0.0</version>
+    <version>1.2.0.1</version>
 	<author>Courseplay.devTeam, tn4799</author>
 	<title>
 		<en>Challenge Mode</en>
@@ -54,6 +54,9 @@ V1.1.0.1
 V1.2.0.0
  - Added an option for decreasing points if farm has a loan
  - Added an option to hide the other farms points, or pay to spy on the points as long as you are inside the menu
+
+V1.2.0.1
+ - Fixed a bug with the synchronization of additional points
 ]]>
 </en>
 		<de><![CDATA[
@@ -101,6 +104,9 @@ V1.1.0.1
 V1.2.0.0
  - Option hinzugefügt, dass ein Hof Punkte verliert, sollte der Hof einen Kredit haben
  - Option hinzugefügt um die Punktezusammensetzung der anderen Farmen zu verstecken, oder bazahle um die Punkte zu sehen solange du im Menü bist
+
+V1.2.0.1
+ - Fehler bei der Synchronisation der zusätzlichen Punkte behoben
 ]]></de>
        <fr><![CDATA[
 Voici le Farming compétitif !

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
-<modDesc descVersion="77">
-    <version>1.2.0.1</version>
+<modDesc descVersion="79">
+    <version>1.2.0.3</version>
 	<author>Courseplay.devTeam, tn4799</author>
 	<title>
 		<en>Challenge Mode</en>
@@ -57,6 +57,12 @@ V1.2.0.0
 
 V1.2.0.1
  - Fixed a bug with the synchronization of additional points
+
+V1.2.0.2
+ - Added support for object storage (only giants version)
+
+V1.2.0.3
+ - Fixed a bug where bales lose on the map gave double points
 ]]>
 </en>
 		<de><![CDATA[
@@ -107,6 +113,12 @@ V1.2.0.0
 
 V1.2.0.1
  - Fehler bei der Synchronisation der zusätzlichen Punkte behoben
+
+V1.2.0.2
+ - Unterstützung für Objektlager hinzugefügt (nur Giants-Version)
+
+V1.2.0.3
+ - Fehler behoben, der dazu führte, dass Ballen auf der Karte doppelte Punkte brachten
 ]]></de>
        <fr><![CDATA[
 Voici le Farming compétitif !

--- a/scripts/VictoryPointManager.lua
+++ b/scripts/VictoryPointManager.lua
@@ -108,9 +108,9 @@ function VictoryPointManager:writeStream(streamId, connection)
 	streamWriteInt32(streamId, self.victoryGoal)
 
 	--tell client number of elements
-	streamWriteInt32(streamId, #self.additionalPoints)
+	streamWriteInt32(streamId, table.size(self.additionalPoints))
 	for farmId, points in pairs(self.additionalPoints) do
-		streamWriteInt32(streamId, #points)
+		streamWriteInt32(streamId, table.size(points))
 		for _, point in pairs(points) do
 			streamWriteInt8(streamId, farmId)
 			streamWriteInt32(streamId, point.points)

--- a/scripts/VictoryPointsUtil.lua
+++ b/scripts/VictoryPointsUtil.lua
@@ -71,12 +71,13 @@ function VictoryPointsUtil.getBaleAmount(farmId, maxFillLevel)
 	maxFillLevel = maxFillLevel == Rule.MAX_FILL_LEVEL_DISABLED and math.huge or maxFillLevel
 
 	local baleFillLevels = {}
-	for _, object in pairs(g_currentMission.nodeToObject) do
-		if object:isa(Bale) and object:getOwnerFarmId(farmId) == farmId and not object.isMissionBale then
-			if baleFillLevels[object.fillType] == nil then
-				baleFillLevels[object.fillType] = 0
+	for _, object in pairs(g_currentMission.itemSystem.itemsToSave) do
+		local bale = object.item
+		if bale:isa(Bale) and bale.ownerFarmId == farmId and not bale.isMissionBale then
+			if baleFillLevels[bale.fillType] == nil then
+				baleFillLevels[bale.fillType] = 0
 			end
-			baleFillLevels[object.fillType] = math.min(baleFillLevels[object.fillType] + object.fillLevel, maxFillLevel)
+			baleFillLevels[bale.fillType] = math.min(baleFillLevels[bale.fillType] + bale.fillLevel, maxFillLevel)
 		end
 	end
 

--- a/scripts/VictoryPointsUtil.lua
+++ b/scripts/VictoryPointsUtil.lua
@@ -36,6 +36,24 @@ function VictoryPointsUtil.getStorageAmount(farmId, maxFillLevel)
 		end
 	end
 
+	local objectStorages = table.filter(g_currentMission.placeableSystem.placeables, function (placeable)
+        return SpecializationUtil.hasSpecialization(PlaceableObjectStorage, placeable.specializations)
+    end)
+	-- add support for object storage (giants variant)
+	for _, placeable in pairs(objectStorages) do
+        local objectStorageSpec = placeable.spec_objectStorage
+
+        for _, abstractObject in pairs(objectStorageSpec.storedObjects) do
+			local palletObject = abstractObject.palletAttributes
+			if palletObject ~= nil and palletObject.ownerFarmId == farmId then
+                if totalFillLevels[palletObject.fillType] == nil then
+                    totalFillLevels[palletObject.fillType] = 0
+                end
+                totalFillLevels[palletObject.fillType] = math.min(totalFillLevels[palletObject.fillType] + palletObject.fillLevel, maxFillLevel)
+            end
+        end
+	end
+
 	CmUtil.debug("Total storage of: %.2f", totalFillLevel )
 	return totalFillLevels
 end
@@ -62,21 +80,22 @@ function VictoryPointsUtil.getBaleAmount(farmId, maxFillLevel)
 		end
 	end
 
+    local objectStorages = table.filter(g_currentMission.placeableSystem.placeables, function (placeable)
+        return SpecializationUtil.hasSpecialization(PlaceableObjectStorage, placeable.specializations)
+    end)
 	-- add support for object storage (giants variant)
-	for _, placeable in pairs(g_currentMission.placeables) do
-		if SpecializationUtil.hasSpecialization(PlaceableObjectStorage, placeable.specializations) then
-			local objectStorageSpec = placeable.spec_objectStorage
+	for _, placeable in pairs(objectStorages) do
+        local objectStorageSpec = placeable.spec_objectStorage
 
-			for _, abstractObject in pairs(objectStorageSpec.storedObjects) do
-				local baleObject = abstractObject.baleObject
-				if abstractObject:isa(AbstractBaleObject) and baleObject:getOwnerFarmId(farmId) == farmId and not baleObject.isMissionBale then
-					if baleFillLevels[baleObject.fillType] == nil then
-						baleFillLevels[baleObject.fillType] = 0
-					end
-					baleFillLevels[baleObject.fillType] = math.min(baleFillLevels[baleObject.fillType] + baleObject.fillLevel, maxFillLevel)
-				end
-			end
-		end
+        for _, abstractObject in pairs(objectStorageSpec.storedObjects) do
+			local baleObject = abstractObject.baleAttributes
+			if baleObject ~= nil and baleObject.farmId == farmId and not baleObject.isMissionBale then
+                if baleFillLevels[baleObject.fillType] == nil then
+                    baleFillLevels[baleObject.fillType] = 0
+                end
+                baleFillLevels[baleObject.fillType] = math.min(baleFillLevels[baleObject.fillType] + baleObject.fillLevel, maxFillLevel)
+            end
+        end
 	end
 	return baleFillLevels
 end

--- a/scripts/VictoryPointsUtil.lua
+++ b/scripts/VictoryPointsUtil.lua
@@ -69,7 +69,7 @@ function VictoryPointsUtil.getBaleAmount(farmId, maxFillLevel)
 
 			for _, abstractObject in pairs(objectStorageSpec.storedObjects) do
 				local baleObject = abstractObject.baleObject
-				if abstractObject:isa(AbstractBaleObject) and baleObject:getOwnerFarmId(farmId) == farmId then
+				if abstractObject:isa(AbstractBaleObject) and baleObject:getOwnerFarmId(farmId) == farmId and not baleObject.isMissionBale then
 					if baleFillLevels[baleObject.fillType] == nil then
 						baleFillLevels[baleObject.fillType] = 0
 					end

--- a/scripts/VictoryPointsUtil.lua
+++ b/scripts/VictoryPointsUtil.lua
@@ -61,6 +61,23 @@ function VictoryPointsUtil.getBaleAmount(farmId, maxFillLevel)
 			baleFillLevels[object.fillType] = math.min(baleFillLevels[object.fillType] + object.fillLevel, maxFillLevel)
 		end
 	end
+
+	-- add support for object storage (giants variant)
+	for _, placeable in pairs(g_currentMission.placeables) do
+		if SpecializationUtil.hasSpecialization(PlaceableObjectStorage, placeable.specializations) then
+			local objectStorageSpec = placeable.spec_objectStorage
+
+			for _, abstractObject in pairs(objectStorageSpec.storedObjects) do
+				local baleObject = abstractObject.baleObject
+				if abstractObject:isa(AbstractBaleObject) and baleObject:getOwnerFarmId(farmId) == farmId then
+					if baleFillLevels[baleObject.fillType] == nil then
+						baleFillLevels[baleObject.fillType] = 0
+					end
+					baleFillLevels[baleObject.fillType] = math.min(baleFillLevels[baleObject.fillType] + baleObject.fillLevel, maxFillLevel)
+				end
+			end
+		end
+	end
 	return baleFillLevels
 end
 


### PR DESCRIPTION
- Bales in storages still count as bales
- Mission bales in storages are still ignored

Fixes #43 